### PR TITLE
update copyright year to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ The server will rebuild the site every time a file changes, with the exception o
 
 # License
 
-© 2018 University of Applied Sciences Amsterdam, City of Amsterdam and the Foundation for Public Code
+© 2021 University of Applied Sciences Amsterdam, City of Amsterdam and the Foundation for Public Code


### PR DESCRIPTION
It's not 2018 anymore. This will also nudge the repo to pull in new changes to the footer ([Jekyll theme PR 68](https://github.com/publiccodenet/jekyll-theme/pull/68)).

-----
[View rendered README.md](https://github.com/publiccodenet/smart-cities-public-code/blob/ElenaFdR-patch-1/README.md)